### PR TITLE
Add support for variable substitution in `@media` parameters

### DIFF
--- a/index.js
+++ b/index.js
@@ -96,7 +96,7 @@ module.exports = postcss.plugin('postcss-advanced-variables', function (opts) {
 		if (node.name === 'for') index = eachAtForRule(node, parent, index);
 		else if (node.name === 'each') index = eachAtEachRule(node, parent, index);
 		else if (node.name === 'if') index = eachAtIfRule(node, parent, index);
-
+		else if (node.name === 'media') node.params = getVariableTransformedString(parent, node.params);
 		return index;
 	}
 

--- a/test/test.js
+++ b/test/test.js
@@ -25,6 +25,24 @@ describe('basic usage', function () {
 		);
 	});
 
+	it('variables in simple media', function (done) {
+		test(
+			'$x: 600px; @media (min-width: $x) {}',
+			'@media (min-width: 600px) {}',
+			{},
+			done
+		);
+	});
+
+	it('variables in complex media', function (done) {
+		test(
+			'$x: 600px; $orientation: landscape; @media not (min-width: $x), handheld and (orientation: $orientation) {}',
+			'@media not (min-width: 600px), handheld and (orientation: landscape) {}',
+			{},
+			done
+		);
+	});
+
 	it('fors', function (done) {
 		test(
 			'@for $i from 1 to 5 by 2 { .x-$i {} } @for $i from 5 to 1 by 2 { .y-$i {} } .z {}',


### PR DESCRIPTION
This specifically calls out media at-rules and runs the existing variable substitution step against its parameters.