### PR TITLE
Optionally receive loop index when using @each

### DIFF
--- a/index.js
+++ b/index.js
@@ -148,8 +148,10 @@ module.exports = postcss.plugin('postcss-advanced-variables', function (opts) {
 	function eachAtEachRule(node, parent, index) {
 		// set params
 		var params = node.params.split(' in ');
+		var args = params[0].trim().split(' ');
 
-		var name  = params[0].trim().slice(1);
+		var name  = args[0].trim().slice(1);
+		var iter  = args.length > 1 ? args[1].trim().slice(1) : null;
 		var array = getArrayedString(getVariableTransformedString(node, params.slice(1).join(' in ')), true);
 		var start = 0;
 		var end   = array.length;
@@ -158,6 +160,9 @@ module.exports = postcss.plugin('postcss-advanced-variables', function (opts) {
 		while (start < end) {
 			// set iterating variable
 			setVariable(node, name, array[start]);
+			if (iter) {
+				setVariable(node, iter, start);
+			}
 
 			// clone node
 			var clone = node.clone({ parent: parent, variables: node.variables });

--- a/test/fixtures/mixed.css
+++ b/test/fixtures/mixed.css
@@ -50,3 +50,9 @@ $dir: assets/images;
 		}
 	}
 }
+
+@each $color $i in (red, white, blue) {
+	:nth-child($i) {
+		color: $color;
+	}
+}

--- a/test/fixtures/mixed.expect.css
+++ b/test/fixtures/mixed.expect.css
@@ -87,3 +87,18 @@
 
     background: url(assets/images/3.png)
 }
+
+:nth-child(0) {
+
+    color: red
+}
+
+:nth-child(1) {
+
+    color: white
+}
+
+:nth-child(2) {
+
+    color: blue
+}


### PR DESCRIPTION
Adds support for the following syntax:

``` scss
$array: (foo, bar, baz);
@each $item $index in $array {
  // ... create rules with $item and $index ...
}
```

If the usage does not expect the second input parameter (in this case, `$index`), then `@each` functions as it did before. If there are simpler/better ways of doing this, I am interested.

Simple test provided.
