### PR TITLE
Add support for #{$var} syntax (postcss-scss)

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ module.exports = postcss.plugin('postcss-advanced-variables', function (opts) {
 	// --------
 
 	var isVariableDeclaration = /^\$[\w-]+$/;
-	var variablesInString = /(^|[^\\])\$(?:\(([A-z][\w-]*)\)|([A-z][\w-]*))/g;
+	var variablesInString = /(^|[^\\])(?:#\{\$([A-z][\w-]*)\}|\$\(([A-z][\w-]*)\)|\$([A-z][\w-]*))/g;
 	var wrappingParen = /^\((.*)\)$/g;
 	var isDefaultValue = /\s+!default$/;
 
@@ -44,8 +44,8 @@ module.exports = postcss.plugin('postcss-advanced-variables', function (opts) {
 
 	// 'Hello $NAME' => 'Hello VALUE'
 	function getVariableTransformedString(node, string) {
-		return string.replace(variablesInString, function (match, before, name1, name2) {
-			var value = getVariable(node, name1 || name2);
+		return string.replace(variablesInString, function (match, before, name1, name2, name3) {
+			var value = getVariable(node, name1 || name2 || name3);
 
 			return value === undefined ? match : before + value;
 		});

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "postcss-advanced-variables",
-  "version": "1.2.2",
+  "version": "1.2.2-patched",
   "description": "PostCSS plugin that enables Sass-like variables, conditionals, and iterators in CSS",
   "keywords": [
     "postcss",
@@ -31,6 +31,7 @@
   },
   "devDependencies": {
     "eslint": "^1.7.3",
+    "postcss-scss": "^0.1.3",
     "tap-spec": "^4.1.0",
     "tape": "^4.2.2"
   },

--- a/test/fixtures/scss.css
+++ b/test/fixtures/scss.css
@@ -1,0 +1,17 @@
+$x: red;
+$y: 50px;
+
+.some-$x {
+  color: green;
+  width: calc(100px + $y);
+}
+
+.other-$(x) {
+  color: green;
+  width: calc(100px + $(y));
+}
+
+.thing-#{$x} {
+  color: green;
+  width: calc(100px + #{$y});
+}

--- a/test/fixtures/scss.expect.css
+++ b/test/fixtures/scss.expect.css
@@ -1,0 +1,14 @@
+.some-red {
+  color: green;
+  width: calc(100px + 50px);
+}
+
+.other-red {
+  color: green;
+  width: calc(100px + 50px);
+}
+
+.thing-red {
+  color: green;
+  width: calc(100px + 50px);
+}

--- a/test/index.js
+++ b/test/index.js
@@ -13,11 +13,17 @@ var tests = {
 		},
 		'mixed': {
 			message: 'supports mixed usage'
+		},
+		'scss': {
+			message: 'supports scss interpolation',
+			options: {
+				syntax: require('postcss-scss')
+			}
 		}
 	}
 };
 
-var debug = false;
+var debug = true;
 var dir   = './test/fixtures/';
 
 var fs      = require('fs');


### PR DESCRIPTION
Modified to latest postcss-advanced-variables code from https://github.com/zobzn/postcss-advanced-variables/commit/2414cd24838cacdb7e152d9fe3b5b829b7d22c8b (@zobzn)

Original pull request: #15 
