### PR TITLE
Error for Undefined Variables with "Silent" Option

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,13 @@ grunt.initConfig({
 
 ## Options
 
+### `silent`
+
+Type: `Boolean`
+Default: `false`
+
+Silences errors thrown when undefined variables are used. By default errors are thrown.
+
 ### `variables`
 
 Type: `Object`  

--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@ var postcss = require('postcss');
 
 module.exports = postcss.plugin('postcss-advanced-variables', function (opts) {
 	opts = opts || {};
+	opts.silent = opts.silent || false;
 
 	// Matchers
 	// --------
@@ -26,6 +27,8 @@ module.exports = postcss.plugin('postcss-advanced-variables', function (opts) {
 	// $NAME => VALUE
 	function getVariable(node, name) {
 		var value = node.variables && name in node.variables ? node.variables[name] : node.parent && getVariable(node.parent, name);
+
+		if (!opts.silent && value === undefined) throw new Error('Unknown CSS variable $' + name);
 
 		return value;
 	}


### PR DESCRIPTION
Not having errors for undefined variables is a major deal breaker for our project. I can't imagine it not being a major plus for most users of this plugin.