### PR TITLE
2.3.0

### DIFF
--- a/.tape.js
+++ b/.tape.js
@@ -59,6 +59,9 @@ module.exports = {
 				importPaths: 'test/imports'
 			}
 		},
+		'imports-media': {
+			message: 'supports @import with media usage'
+		},
 		'mixed': {
 			message: 'supports mixed usage'
 		},

--- a/.tape.js
+++ b/.tape.js
@@ -14,7 +14,7 @@ module.exports = {
 		'default:var-func': {
 			message: 'supports !default { variables() } usage',
 			options: {
-				variables: (name, node) => 'custom-fn-value'
+				variables: () => 'custom-fn-value'
 			}
 		},
 		'variables': {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changes to PostCSS Advanced Variables
 
+### 2.3.0 (January 6, 2018)
+
+- Added: `importFilter` option to accept or ignore imports by function or regex
+- Added: Support for media parameters after `@import` rules
+- Added: Support for case-insensitive at-rules
+- Fixed: Protocol and protocol-less imports are ignored
+
 ### 2.2.0 (January 2, 2018)
 
 - Added: Support for `@import`

--- a/README.md
+++ b/README.md
@@ -514,6 +514,21 @@ require('postcss-advanced-variables')({
 });
 ```
 
+#### importFilter
+
+The `importFilter` option determines whether an import will be inlined.
+
+The `importFilter` option can be a function or an regular expression.
+
+By default, imports are ignored if they begin with a protocol or
+protocol-relative slashes (`//`).
+
+```js
+require('postcss-advanced-variables')({
+  importPaths: ['path/to/files', 'another/path/to/files']
+});
+```
+
 #### importRoot
 
 The `importRoot` option defines the root directory used by imports when the

--- a/README.md
+++ b/README.md
@@ -135,6 +135,279 @@ grunt.initConfig({
 });
 ```
 
+---
+
+## Features
+
+### $variables
+
+Variables let you store information to be reused anywhere in a stylesheet.
+
+Variables are set just like CSS properties, placing a `$` symbol before the
+name of the variable (`$var-name`). They may also be set placing a `$` symbol
+before two parentheses wrapping the name of the variable (`$(var-name)`), or by
+wrapping the `$` symbol and variable name in curly braces preceeded by a hash
+(`#{$var-name}`).
+
+```scss
+$font-size:     1.25em;
+$font-stack:    "Helvetica Neue", sans-serif;
+$primary-color: #333;
+
+body {
+  font: $font-size $(font-stack);
+  color: #{$primary-color};
+}
+```
+
+In that example, `$font-size`, `$font-stack`, and `$primary-color` are replaced
+with their values.
+
+```css
+body {
+  font: 1.25em "Helvetica Neue", sans-serif;
+  color: #333;
+}
+```
+
+### @if and @else Rules
+
+Conditionals like `@if` and `@else` let you use rules in a stylesheet if they
+evaluate true or false.
+
+Conditionals are set by writing `@if` before the expression you want to
+evaluate. If the expression is true, then its contents are included in the
+stylesheet. If the expression is false, then its contents are not included, but
+the contents of an `@else` that follows it are included.
+
+```scss
+$type: monster;
+
+p {
+  @if $type == ocean {
+    color: blue;
+  } @else {
+    color: black;
+  }
+}
+```
+
+In that example, `$type === ocean` is false, so the `@if` contents are ignored
+and the `@else` contents are used.
+
+```css
+p {
+  color: black;
+}
+```
+
+### @for and @each Rules
+
+Iterators like `@for` and `@each` let you repeat content in a stylesheet.
+
+A `@for` statement repeats by a numerical counter defined as a variable.
+
+It can be written as `@for $counter from <start> through <end>` where
+`$counter` is the name of the iterating variable, `<start>` is the number to
+start with, and `<end>` is the number to finish with.
+
+It can also be written as `@for $counter from <start> to <end>` where
+`$counter` is still the name of the counter variable, `<start>` is still the
+number to start with, but `<end>` is now the number to finish
+*before, but not include*.
+
+When `<start>` is greater than `<end>`, the counter will decrement instead of
+increment.
+
+Either form of `@for` can be written as
+`@for $var from <start> to <end> by <increment>` or
+`@for $var from <start> through <end> by <increment>`
+where `<incremement>` is the amount the counter variable will advance.
+
+```scss
+@for $i from 1 through 5 by 2 {
+  .width-#{$i} {
+    width: #{$i}0em;
+  }
+}
+
+@for $j from 1 to 5 by 2 {
+  .height-#{$j} {
+    height: #{$j}0em;
+  }
+}
+```
+
+In that example, `$i` is repeated from 1 through 5 by 2, which means it is
+repeated 3 times (1, 3, and 5). Meanwhile, `$j` is repeated from 1 to 5 by 2,
+which means it is repeated 2 times (1 and 3).
+
+```css
+.width-1 {
+  width: 10em;
+}
+
+.width-3 {
+  width: 30em;
+}
+
+.width-5 {
+  width: 50em;
+}
+
+.height-1 {
+  height: 10em;
+}
+
+.height-3 {
+  height: 30em;
+}
+```
+
+An `@each` statement statement repeats through a list of values.
+
+It can be written as `@each $item in $list` where `$item` is the
+name of the iterating variable and `$list` is the list of values being looped
+over.
+
+```scss
+@each $animal in (puma, sea-slug, egret, salamander) {
+  .#{$animal}-icon {
+    background-image: url("images/icon-#{$animal}.svg");
+  }
+}
+```
+
+In that example, a list of 4 animals is looped over to create 4 unique
+classnames.
+
+```css
+.puma-icon {
+  background-image: url("images/icon-puma.svg");
+}
+
+.sea-slug-icon {
+  background-image: url("images/icon-sea-slug.svg");
+}
+
+.egret-icon {
+  background-image: url("images/icon-egret.svg");
+}
+
+.salamander-icon {
+  background-image: url("images/icon-salamander.svg");
+}
+```
+
+It can also be written as `@each $item $counter in $list` where `$item` is
+still the name of the iterating variable and `$list` is still the list of values
+being looped over, but now `$counter` is the numerical counter.
+
+```scss
+@each $animal $i in (puma, sea-slug, egret, salamander) {
+  .#{$animal}-icon {
+    background-image: url("images/icon-#{$i}.svg");
+  }
+}
+```
+
+```css
+.puma-icon {
+  background-image: url("images/icon-1.svg");
+}
+
+.sea-slug-icon {
+  background-image: url("images/icon-2.svg");
+}
+
+.egret-icon {
+  background-image: url("images/icon-3.svg");
+}
+
+.salamander-icon {
+  background-image: url("images/icon-4.svg");
+}
+```
+
+In that example, a list of 4 animals is looped over to create 4 unique
+classnames.
+
+### @mixin, @include, and @content rules
+
+Mixins let you reuse rule in a stylesheet. A `@mixin` defines the content you
+want to reuse, while an `@include` rule includes it anywhere in your stylesheet.
+
+Mixins are set by writing `@mixin` before the name of the mixin you define.
+This can be (optionally) followed by comma-separated variables you
+want to use inside of it. Mixins are then used anywhere by writing `@include`
+before the name of the mixin you are using. This is (again, optionally)
+followed by some comma-separated arguments you want to pass into the mixin as
+the (aforementioned) variables.
+
+```scss
+@mixin heading-text {
+  color: #242424;
+  font-size: 4em;
+}
+
+h1, h2, h3 {
+  @include heading-text;
+}
+
+.some-heading-component > :first-child {
+  @include heading-text;
+}
+```
+
+In that example, `@include heading-text` is replaced with its contents.
+
+```css
+h1, h2, h3 {
+  color: #242424;
+  font-size: 4em;
+}
+
+.some-heading-component > :first-child {
+  color: #242424;
+  font-size: 4em;
+}
+```
+
+Remember, mixins can be followed by comma-separated variables you
+want to pass into the mixin as variables.
+
+```scss
+@mixin heading-text($color: #242424, $font-size: 4em) {
+  color: $color;
+  font-size: $font-size;
+}
+
+h1, h2, h3 {
+  @include heading-text;
+}
+
+.some-heading-component > :first-child {
+  @include heading-text(#111111, 6em);
+}
+```
+
+In that example, `@include heading-text` is replaced with its contents, but
+this time some of their contents are customized with variables.
+
+```css
+h1, h2, h3 {
+  color: #242424;
+  font-size: 4em;
+}
+
+.some-heading-component > :first-child {
+  color: #111111;
+  font-size: 6em;
+}
+```
+
+---
+
 ## Options
 
 ### variables
@@ -205,6 +478,8 @@ require('postcss-advanced-variables')({
 ```
 
 ### Import Options
+
+These options only apply to the `@import` at-rule.
 
 #### importPaths
 

--- a/index.js
+++ b/index.js
@@ -13,6 +13,9 @@ export default postcss.plugin('postcss-advanced-variables', opts => (root, resul
 	const unresolvedOpt = String(Object(opts).unresolved || 'throw').toLowerCase();
 	const variablesOpt  = Object(opts).variables;
 	const importCache   = Object(Object(opts).importCache);
+	const importFilter  = Object(opts).filter || (id => {
+		return !matchProtocol.test(id);
+	});
 	const importPaths   = [].concat(Object(opts).importPaths || []);
 	const importPromise = [];
 	const importResolve = Object(opts).resolve || (
@@ -24,6 +27,7 @@ export default postcss.plugin('postcss-advanced-variables', opts => (root, resul
 	transformNode(root, {
 		result,
 		importCache,
+		importFilter,
 		importPaths,
 		importPromise,
 		importResolve,
@@ -35,3 +39,5 @@ export default postcss.plugin('postcss-advanced-variables', opts => (root, resul
 
 	return Promise.all(importPromise);
 });
+
+const matchProtocol = /^(?:[A-z]+:)?\/\//;

--- a/lib/transform-import-atrule.js
+++ b/lib/transform-import-atrule.js
@@ -10,42 +10,47 @@ export default function transformImportAtrule(rule, opts) {
 	// if @import is supported
 	if (opts.transform.includes('@import')) {
 		// @import options
-		const { id, cwf, cwd } = getImportOpts(rule);
+		const { id, media, cwf, cwd } = getImportOpts(rule);
 
-		const cwds = [cwd].concat(opts.importPaths);
+		if (
+			(opts.importFilter instanceof Function && opts.importFilter(id, media)) ||
+			(opts.importFilter instanceof RegExp && opts.importFilter.test(id))
+		) {
+			const cwds = [cwd].concat(opts.importPaths);
 
-		// promise the resolved file and its contents using the file resolver
-		const importPromise = cwds.reduce(
-			(promise, thiscwd) => promise.catch(
-				() => opts.importResolve(id, thiscwd, opts)
-			),
-			Promise.reject()
-		);
-
-		opts.importPromise.push(
-			importPromise.then(
-				// promise the processed file
-				({ file, contents }) => processor.process(contents, { from: file }).then(
-					({ root }) => {
-						// push a dependency message
-						opts.result.messages.push({ type: 'dependency', file: file, parent: cwf });
-
-						// imported nodes
-						const nodes = root.nodes.slice(0);
-
-						// replace the @import at-rule with the imported nodes
-						rule.replaceWith(nodes);
-
-						// transform all nodes from the import
-						transformNode({ nodes }, opts);
-					}
+			// promise the resolved file and its contents using the file resolver
+			const importPromise = cwds.reduce(
+				(promise, thiscwd) => promise.catch(
+					() => opts.importResolve(id, thiscwd, opts)
 				),
-				() => {
-					// otherwise, if the @import could not be found
-					manageUnresolved(rule, opts, '@import', `Could not resolve the @import for "${id}"`);
-				}
-			)
-		);
+				Promise.reject()
+			);
+
+			opts.importPromise.push(
+				importPromise.then(
+					// promise the processed file
+					({ file, contents }) => processor.process(contents, { from: file }).then(
+						({ root }) => {
+							// push a dependency message
+							opts.result.messages.push({ type: 'dependency', file: file, parent: cwf });
+
+							// imported nodes
+							const nodes = root.nodes.slice(0);
+
+							// replace the @import at-rule with the imported nodes
+							rule.replaceWith(nodes);
+
+							// transform all nodes from the import
+							transformNode({ nodes }, opts);
+						}
+					),
+					() => {
+						// otherwise, if the @import could not be found
+						manageUnresolved(rule, opts, '@import', `Could not resolve the @import for "${id}"`);
+					}
+				)
+			);
+		}
 	}
 }
 

--- a/lib/transform-import-atrule.js
+++ b/lib/transform-import-atrule.js
@@ -37,8 +37,24 @@ export default function transformImportAtrule(rule, opts) {
 							// imported nodes
 							const nodes = root.nodes.slice(0);
 
-							// replace the @import at-rule with the imported nodes
-							rule.replaceWith(nodes);
+							// if media params were detected
+							if (media) {
+								// create a new media rule
+								const mediaRule = postcss.atRule({
+									name: 'media',
+									params: media,
+									source: rule.source
+								});
+
+								// append with the imported nodes
+								mediaRule.append(nodes);
+
+								// replace the @import at-rule with the @media at-rule
+								rule.replaceWith(mediaRule);
+							} else {
+								// replace the @import at-rule with the imported nodes
+								rule.replaceWith(nodes);
+							}
 
 							// transform all nodes from the import
 							transformNode({ nodes }, opts);

--- a/lib/transform-node.js
+++ b/lib/transform-node.js
@@ -18,7 +18,7 @@ export default function transformNode(node, opts) {
 			const type = child.type;
 
 			if ('atrule' === type) {
-				const name = child.name;
+				const name = child.name.toLowerCase();
 
 				if ('content' === name) {
 					// transform @content at-rules

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "postcss-advanced-variables",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "description": "Use Sass-like variables, conditionals, and iterators in CSS",
   "author": "Jonathan Neal <jonathantneal@hotmail.com>",
   "license": "CC0-1.0",

--- a/test/imports-alt/import-1.css
+++ b/test/imports-alt/import-1.css
@@ -1,3 +1,0 @@
-.alt-import-1 {
-	content: $pass;
-}

--- a/test/imports-media.css
+++ b/test/imports-media.css
@@ -1,0 +1,3 @@
+$pass: "pass";
+
+@import "imports/import-1" screen and (orientation:landscape);

--- a/test/imports-media.expect.css
+++ b/test/imports-media.expect.css
@@ -1,0 +1,4 @@
+@media screen and (orientation:landscape) {.import-1 {
+	content: "pass";
+}
+}

--- a/test/imports.css
+++ b/test/imports.css
@@ -5,3 +5,4 @@ $pass: "pass";
 @import url("imports/import-1");
 @import url('imports/import-1');
 @import url(imports/import-1);
+@import url(https://necolas.github.io/normalize.css/7.0.0/normalize.css);

--- a/test/imports.expect.css
+++ b/test/imports.expect.css
@@ -13,3 +13,4 @@
 .import-1 {
 	content: "pass";
 }
+@import url(https://necolas.github.io/normalize.css/7.0.0/normalize.css);


### PR DESCRIPTION
- Added: `importFilter` option to accept or ignore imports by function or regex
- Added: Support for media parameters after `@import` rules
- Added: Support for case-insensitive at-rules
- Fixed: Protocol and protocol-less imports are ignored

This also greatly improves documentation by adding descriptions and examples of all of this plugin’s features.