### PR TITLE
Feature/2.3.1

### DIFF
--- a/.rollup.js
+++ b/.rollup.js
@@ -6,6 +6,7 @@ export default {
 	plugins: [
 		babel({
 			plugins: [
+				'array-includes',
 				'external-helpers'
 			],
 			presets: [

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changes to PostCSS Advanced Variables
 
+### 2.3.1 (February 10, 2018)
+
+- Added: `babel-plugin-array-includes` instead of `babel-polyfill`
+- Fixed: `@mixin` rules to support being declared with empty parens
+- Noted: Recommend `postcss-scss-syntax` to best support variable interpolation
+
 ### 2.3.0 (January 6, 2018)
 
 - Added: `importFilter` option to accept or ignore imports by function or regex

--- a/README.md
+++ b/README.md
@@ -160,6 +160,9 @@ body {
 }
 ```
 
+*Note: To use `#{$var-name}` without issues, you will need to include the
+[PostCSS SCSS Syntax].
+
 In that example, `$font-size`, `$font-stack`, and `$primary-color` are replaced
 with their values.
 
@@ -564,6 +567,7 @@ require('postcss-advanced-variables')({
 
 [PostCSS Advanced Variables]: https://github.com/jonathantneal/postcss-advanced-variables
 [PostCSS]: https://github.com/postcss/postcss
+[PostCSS SCSS Syntax]: https://github.com/postcss/postcss-scss
 [Gulp PostCSS]: https://github.com/postcss/gulp-postcss
 [Grunt PostCSS]: https://github.com/nDmitry/grunt-postcss
 [Sass Import Resolve Specification]: https://jonathantneal.github.io/sass-import-resolve/

--- a/index.js
+++ b/index.js
@@ -1,5 +1,4 @@
 // tooling
-import 'babel-polyfill';
 import transformNode from './lib/transform-node';
 import postcss from 'postcss';
 import resolve from '@csstools/sass-import-resolve';

--- a/lib/transform-mixin-atrule.js
+++ b/lib/transform-mixin-atrule.js
@@ -21,8 +21,8 @@ export default function transformMixinAtrule(rule, opts) {
 const getMixinOpts = node => {
 	// @mixin name and default params ([{ name, value }, ...])
 	const [ name, sourceParams ] = node.params.split(matchOpeningParen, 2);
-	const params = sourceParams
-		? list.comma(sourceParams.slice(0, -1)).map(
+	const params = sourceParams && sourceParams.slice(0, -1).trim()
+		? list.comma(sourceParams.slice(0, -1).trim()).map(
 			param => {
 				const parts = list.split(param, ':');
 				const paramName  = parts[0].slice(1);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "postcss-advanced-variables",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "description": "Use Sass-like variables, conditionals, and iterators in CSS",
   "author": "Jonathan Neal <jonathantneal@hotmail.com>",
   "license": "CC0-1.0",

--- a/package.json
+++ b/package.json
@@ -26,14 +26,14 @@
     "node": ">=4.0.0"
   },
   "dependencies": {
-    "@csstools/sass-import-resolve": "^1.0.0",
-    "babel-polyfill": "^6.26.0",
+    "@csstools/sass-import-resolve": "^1.0",
     "postcss": "^6.0"
   },
   "devDependencies": {
     "babel-core": "^6.26",
     "babel-eslint": "^8.2",
-    "babel-plugin-external-helpers": "^6.22.0",
+    "babel-plugin-array-includes": "^2.0.3",
+    "babel-plugin-external-helpers": "^6.22",
     "babel-preset-env": "^1.6",
     "echint": "^4.0",
     "eslint": "^4.17",

--- a/package.json
+++ b/package.json
@@ -32,16 +32,16 @@
   },
   "devDependencies": {
     "babel-core": "^6.26",
-    "babel-eslint": "^8.1",
+    "babel-eslint": "^8.2",
     "babel-plugin-external-helpers": "^6.22.0",
     "babel-preset-env": "^1.6",
     "echint": "^4.0",
-    "eslint": "^4.14",
+    "eslint": "^4.17",
     "eslint-config-dev": "2.0",
-    "postcss-scss": "^1.0.2",
+    "postcss-scss": "^1.0.3",
     "postcss-tape": "2.2",
     "pre-commit": "^1.2",
-    "rollup": "^0.53",
+    "rollup": "^0.55",
     "rollup-plugin-babel": "^3.0"
   },
   "eslintConfig": {

--- a/test/mixins.css
+++ b/test/mixins.css
@@ -5,21 +5,28 @@
 	border-radius: 1em;
 }
 
-@mixin mixin-test-2($radius) {
+@mixin mixin-test-2() {
+	-webkit-border-radius: 1em;
+	-moz-border-radius: 1em;
+	-ms-border-radius: 1em;
+	border-radius: 1em;
+}
+
+@mixin mixin-test-3($radius) {
 	-webkit-border-radius: $radius;
 	-moz-border-radius: $radius;
 	-ms-border-radius: $radius;
 	border-radius: $radius;
 }
 
-@mixin mixin-test-3($radius: 1em) {
+@mixin mixin-test-4($radius: 1em) {
 	-webkit-border-radius: $radius;
 	-moz-border-radius: $radius;
 	-ms-border-radius: $radius;
 	border-radius: $radius;
 }
 
-@mixin mixin-test-4($min-width: 30em) {
+@mixin mixin-test-5($min-width: 30em) {
 	@media (min-width: $min-width) {
 		@content;
 	}
@@ -30,25 +37,29 @@
 }
 
 .test-2 {
-	@include mixin-test-2(1em);
+	@include mixin-test-2();
 }
 
-.test-3a {
-	@include mixin-test-3;
-}
-
-.test-3b {
-	@include mixin-test-3(2em);
+.test-3 {
+	@include mixin-test-3(1em);
 }
 
 .test-4a {
-	@include mixin-test-4 {
+	@include mixin-test-4;
+}
+
+.test-4b {
+	@include mixin-test-4(2em);
+}
+
+.test-5a {
+	@include mixin-test-5 {
 		min-width: $min-width;
 	}
 }
 
-.test-4b {
-	@include mixin-test-4(60em) {
+.test-5b {
+	@include mixin-test-5(60em) {
 		min-width: $min-width;
 	}
 }

--- a/test/mixins.expect.css
+++ b/test/mixins.expect.css
@@ -12,27 +12,34 @@
 	border-radius: 1em;
 }
 
-.test-3a {
+.test-3 {
 	-webkit-border-radius: 1em;
 	-moz-border-radius: 1em;
 	-ms-border-radius: 1em;
 	border-radius: 1em;
 }
 
-.test-3b {
+.test-4a {
+	-webkit-border-radius: 1em;
+	-moz-border-radius: 1em;
+	-ms-border-radius: 1em;
+	border-radius: 1em;
+}
+
+.test-4b {
 	-webkit-border-radius: 2em;
 	-moz-border-radius: 2em;
 	-ms-border-radius: 2em;
 	border-radius: 2em;
 }
 
-.test-4a {
+.test-5a {
 	@media (min-width: 30em) {
 		min-width: 30em;
 	}
 }
 
-.test-4b {
+.test-5b {
 	@media (min-width: 60em) {
 		min-width: 60em;
 	}


### PR DESCRIPTION
- Fixes an issue where a `@mixin` written with empty parens throws, resolving #47
- Uses `babel-plugin-array-includes` instead of `babel-polyfill` to support Node 4, resolving #45
- Recommends `postcss-scss-syntax` to support variable interpolation inside selectors, resolving #46