### PR TITLE
Use currently supported node versions for CI

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -2,7 +2,9 @@
 
 environment:
   matrix:
-    - nodejs_version: 4.0
+    - nodejs_version: "10"
+    - nodejs_version: "8"
+    - nodejs_version: "6"
 
 version: "{build}"
 build: off

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,11 @@
-# https://docs.travis-ci.com/user/travis-lint
+# https://docs.travis-ci.com/user/languages/javascript-with-nodejs/
 
 language: node_js
 
 node_js:
-  - 4
+  - 10
+  - 8
+  - 6
 
 install:
   - npm install --ignore-scripts


### PR DESCRIPTION
CI was set up to only build on node version `4.0`, however node 4 reached end of life on 2018-04-30. See <https://github.com/nodejs/Release#end-of-life-releases>.

This PR simply changes the CI configs to the currently supported node versions; `10.x`, `8.x`, and `6.x`.