### PR TITLE
Allow for CSS variables to be used with mixins

### DIFF
--- a/src/lib/transform-include-atrule.js
+++ b/src/lib/transform-include-atrule.js
@@ -62,4 +62,4 @@ const getIncludeOpts = node => {
 };
 
 // match an opening parenthesis
-const matchOpeningParen = '(';
+const matchOpeningParen = /(?<!var)\(/;

--- a/src/lib/transform-mixin-atrule.js
+++ b/src/lib/transform-mixin-atrule.js
@@ -40,4 +40,4 @@ const getMixinOpts = (node, opts) => {
 };
 
 // match an opening parenthesis
-const matchOpeningParen = '(';
+const matchOpeningParen = /(?<!var)\(/;


### PR DESCRIPTION
Fixes #78 . Allows for CSS variables to be set as the default value for a mixin or passed as a parameter.

Example:
```
@mixin set-color($color: var(--text-color)) {
  color: $color;
}

h3 {
  @include set-color;
}

h4 {
  @include set-color(var(--my-color));
}
```

Before, that resulted in:
```
h3 {
  color: va;
}

h4 {
  color: va;
}
```

After, that results in:
```
h3 {
  color: var(--text-color);
}

h4 {
  color: var(--my-color);
}
```